### PR TITLE
APPS-2968: library also should update annotation of method that updat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Spryker - PropelEncryptionBehavior
 
 [![Build Status](https://github.com/spryker/propel-encryption-behavior/workflows/CI/badge.svg?branch=master)](https://github.com/spryker/propel-encryption-behavior/actions?query=workflow%3ACI+branch%3Amaster)
-[![codecov](https://codecov.io/gh/spryker/propel-encryption-behavior/branch/master/graph/badge.svg?token=L1thFB9nOG)](https://codecov.io/gh/spryker/propel-encryption-behavior)
 [![Latest Stable Version](https://poser.pugx.org/spryker/propel-encryption-behavior/v/stable.svg)](https://packagist.org/packages/spryker/propel-encryption-behavior)
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.3-8892BF.svg)](https://php.net/)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%208-brightgreen.svg?style=flat)](https://phpstan.org/)

--- a/src/EncryptionBehavior.php
+++ b/src/EncryptionBehavior.php
@@ -334,6 +334,8 @@ EOT;
      * @param bool $isSearchable
      * @param bool $hasColumnBlobType
      *
+     * @throws \Exception
+     *
      * @return void
      */
     protected function addEncryptionToSetter(

--- a/src/EncryptionBehavior.php
+++ b/src/EncryptionBehavior.php
@@ -345,7 +345,13 @@ EOT;
         $setterLocation = $this->getMethodLocation($script, "set$columnPhpName");
 
         if ($hasColumnBlobType) {
-            $paramAnnotationLocation = strpos($script, 'param resource', $setterLocation - 300);
+            $previousMethodBracketLocation = strrpos(substr($script, 0, $setterLocation), '}');
+
+            if ($previousMethodBracketLocation === false) {
+                throw new Exception('The bracket of the previous method was not found.');
+            }
+
+            $paramAnnotationLocation = strpos($script, 'param resource', $previousMethodBracketLocation);
             $script = substr_replace($script, 'param string', $paramAnnotationLocation, 14);
         }
 
@@ -383,7 +389,13 @@ EOT;
         $getterLocation = $this->getMethodLocation($script, "get$columnPhpName");
 
         if ($hasColumnBlobType) {
-            $returnAnnotationLocation = strpos($script, 'return resource', $getterLocation - 50);
+            $previousMethodBracketLocation = strrpos(substr($script, 0, $getterLocation), '}');
+
+            if ($previousMethodBracketLocation === false) {
+                throw new Exception('The bracket of the previous method was not found.');
+            }
+
+            $returnAnnotationLocation = strpos($script, 'return resource', $previousMethodBracketLocation);
             $script = substr_replace($script, 'return string', $returnAnnotationLocation, 15);
         }
 
@@ -425,7 +437,7 @@ EOT;
      * @return int
      */
     protected function getMethodLocation(
-        string &$script,
+        string $script,
         string $methodName
     ): int {
         $methodLocation = strpos($script, $methodName);

--- a/src/EncryptionBehavior.php
+++ b/src/EncryptionBehavior.php
@@ -99,10 +99,10 @@ class EncryptionBehavior extends Behavior
             }
 
             $columnPhpName = $column->getPhpName();
-            $hasColumnBlobType = $column->getType() === PropelTypes::BLOB;
+            $isColumnBlobType = $column->getType() === PropelTypes::BLOB;
 
-            $this->addEncryptionToSetter($script, $columnPhpName, $isSearchable, $hasColumnBlobType);
-            $this->addDecryptionToGetter($script, $columnPhpName, $hasColumnBlobType);
+            $this->addEncryptionToSetter($script, $columnPhpName, $isSearchable, $isColumnBlobType);
+            $this->addDecryptionToGetter($script, $columnPhpName, $isColumnBlobType);
         }
     }
 
@@ -332,7 +332,7 @@ EOT;
      * @param string $script
      * @param string $columnPhpName
      * @param bool $isSearchable
-     * @param bool $hasColumnBlobType
+     * @param bool $isColumnBlobType
      *
      * @throws \Exception
      *
@@ -342,15 +342,15 @@ EOT;
         string &$script,
         string $columnPhpName,
         bool $isSearchable,
-        bool $hasColumnBlobType
+        bool $isColumnBlobType
     ): void {
         $setterLocation = $this->getMethodLocation($script, "set$columnPhpName");
 
-        if ($hasColumnBlobType) {
+        if ($isColumnBlobType) {
             $previousMethodBracketLocation = strrpos(substr($script, 0, $setterLocation), '}');
 
             if ($previousMethodBracketLocation === false) {
-                throw new Exception('The bracket of the previous method was not found.');
+                throw new Exception('The bracket of the     previous method was not found.');
             }
 
             $paramAnnotationLocation = strpos($script, 'param resource', $previousMethodBracketLocation);
@@ -377,7 +377,7 @@ EOT;
     /**
      * @param string $script
      * @param string $columnPhpName
-     * @param bool $hasColumnBlobType
+     * @param bool $isColumnBlobType
      *
      * @throws \Exception
      *
@@ -386,11 +386,11 @@ EOT;
     protected function addDecryptionToGetter(
         string &$script,
         string $columnPhpName,
-        bool $hasColumnBlobType
+        bool $isColumnBlobType
     ): void {
         $getterLocation = $this->getMethodLocation($script, "get$columnPhpName");
 
-        if ($hasColumnBlobType) {
+        if ($isColumnBlobType) {
             $previousMethodBracketLocation = strrpos(substr($script, 0, $getterLocation), '}');
 
             if ($previousMethodBracketLocation === false) {

--- a/src/EncryptionBehavior.php
+++ b/src/EncryptionBehavior.php
@@ -99,10 +99,10 @@ class EncryptionBehavior extends Behavior
             }
 
             $columnPhpName = $column->getPhpName();
-            $isColumnBlobType = $column->getType() === PropelTypes::BLOB;
+            $isBlobTypeColumn = $column->getType() === PropelTypes::BLOB;
 
-            $this->addEncryptionToSetter($script, $columnPhpName, $isSearchable, $isColumnBlobType);
-            $this->addDecryptionToGetter($script, $columnPhpName, $isColumnBlobType);
+            $this->addEncryptionToSetter($script, $columnPhpName, $isSearchable, $isBlobTypeColumn);
+            $this->addDecryptionToGetter($script, $columnPhpName, $isBlobTypeColumn);
         }
     }
 
@@ -332,7 +332,7 @@ EOT;
      * @param string $script
      * @param string $columnPhpName
      * @param bool $isSearchable
-     * @param bool $isColumnBlobType
+     * @param bool $isBlobTypeColumn
      *
      * @throws \Exception
      *
@@ -342,11 +342,11 @@ EOT;
         string &$script,
         string $columnPhpName,
         bool $isSearchable,
-        bool $isColumnBlobType
+        bool $isBlobTypeColumn
     ): void {
         $setterLocation = $this->getMethodLocation($script, "set$columnPhpName");
 
-        if ($isColumnBlobType) {
+        if ($isBlobTypeColumn) {
             $previousMethodBracketLocation = strrpos(substr($script, 0, $setterLocation), '}');
 
             if ($previousMethodBracketLocation === false) {
@@ -377,7 +377,7 @@ EOT;
     /**
      * @param string $script
      * @param string $columnPhpName
-     * @param bool $isColumnBlobType
+     * @param bool $isBlobTypeColumn
      *
      * @throws \Exception
      *
@@ -386,11 +386,11 @@ EOT;
     protected function addDecryptionToGetter(
         string &$script,
         string $columnPhpName,
-        bool $isColumnBlobType
+        bool $isBlobTypeColumn
     ): void {
         $getterLocation = $this->getMethodLocation($script, "get$columnPhpName");
 
-        if ($isColumnBlobType) {
+        if ($isBlobTypeColumn) {
             $previousMethodBracketLocation = strrpos(substr($script, 0, $getterLocation), '}');
 
             if ($previousMethodBracketLocation === false) {

--- a/src/EncryptionBehavior.php
+++ b/src/EncryptionBehavior.php
@@ -350,7 +350,7 @@ EOT;
             $previousMethodBracketLocation = strrpos(substr($script, 0, $setterLocation), '}');
 
             if ($previousMethodBracketLocation === false) {
-                throw new Exception('The bracket of the     previous method was not found.');
+                throw new Exception('The bracket of the previous method was not found.');
             }
 
             $paramAnnotationLocation = strpos($script, 'param resource', $previousMethodBracketLocation);

--- a/src/EncryptionBehavior.php
+++ b/src/EncryptionBehavior.php
@@ -9,7 +9,6 @@ namespace Spryker\PropelEncryptionBehavior;
 
 use Exception;
 use Propel\Generator\Model\Behavior;
-use Propel\Generator\Model\Column;
 use Propel\Generator\Model\PropelTypes;
 
 class EncryptionBehavior extends Behavior
@@ -336,8 +335,6 @@ EOT;
      * @param bool $hasColumnBlobType
      *
      * @return void
-     *@throws \Exception
-     *
      */
     protected function addEncryptionToSetter(
         string &$script,
@@ -374,9 +371,9 @@ EOT;
      * @param string $columnPhpName
      * @param bool $hasColumnBlobType
      *
-     * @return void
-     *@throws \Exception
+     * @throws \Exception
      *
+     * @return void
      */
     protected function addDecryptionToGetter(
         string &$script,
@@ -422,6 +419,8 @@ EOT;
     /**
      * @param string $script
      * @param string $methodName
+     *
+     * @throws \Exception
      *
      * @return int
      */


### PR DESCRIPTION
- Developer(s): @oleh.novatskyi 

- Ticket: [APPS-2968](https://spryker.atlassian.net/browse/APPS-2968)

- merge: merge

- release: https://release.spryker.com/release/package?repo=spryker%2Fpropel-encryption-behavior&pr=3

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   PropelEncryptionBehavior | patch                 |                       |

-----------------------------------------

#### Module PropelEncryptionBehavior

##### Change log

Fixes

- Adjusted `EncryptionBehavior::addEncryptionToSetter()` so it updates annotation for for setter method of the column with `BLOB` type. Now they receive `string` instead of `resource`.
- Adjusted `EncryptionBehavior::addDecryptionToGetter()` so it updates annotation for for getter method of the column with `BLOB` type. Now they return `string` instead of `resource`.